### PR TITLE
Update mediatype specifier to ld+json

### DIFF
--- a/docs/api/rest_api.md
+++ b/docs/api/rest_api.md
@@ -16,7 +16,7 @@ Payloads for requests should also be JSON-LD, but Omeka S sometimes requires cli
 to follow a particular structure, even if the same data could be represented by
 alternate valid JSON-LD structures. The Content-Type of a request with a payload
 must be `application/json` (or `multipart/form-data` if sending a multipart request).
-Format specifers (after `+`, i.e., `application/json+ld`, are also allowed).
+Format specifers (before `+`, i.e., `application/ld+json`, are also allowed).
 
 ## Authentication
 


### PR DESCRIPTION
If a mediatype is to be further specified, the extra bit comes before `+`.
The Media type for JSON-LD is `application/ld+json`, not `application/json+ld`.

However, I don't know if Omeka S accepts the correct media type.