### PR TITLE
Added proxy configuration for http_client

### DIFF
--- a/docs/configuration/config_reference.md
+++ b/docs/configuration/config_reference.md
@@ -87,7 +87,15 @@ Configuration for the HTTP client.
     - `sslcapath`: the server path to the SSL certificate directory
     - `sslcafile`: the server path to the SSL certificate file
 
-See [zend-http docs](https://docs.zendframework.com/zend-http/client/adapters/) for configuration options.
+In case your Omeka S instance requires a proxy server for outgoing HTTP traffic, you should set `'adapter' => \Laminas\Http\Client\Adapter\Proxy::class,` and use these additional configuration parameters:
+- `http_client`:
+    - `proxy_host`: the hostname or FQDN of the proxy server
+    - `proxy_port`: the proxy server's TCP port
+    - `proxy_user`: user name for proxy server, if required
+    - `proxy_pass`: password for proxy server, if required
+
+
+See [Laminas http docs](https://docs.laminas.dev/laminas-http/client/adapters/) for configuration options.
 
 ## Installer
 


### PR DESCRIPTION
Dear Omeka S developers, 

I was searching how to configure my Omeka S instance to use a proxy server for outgoing HTTP traffic, but could not find it in the documentation. 
I figured out how to do it and thought it might be useful for others to have it in the Omeka docs, so here's my contribution. 

Best regards,
Maarten Coonen