### PR TITLE
Changed directory names to reflect actual names 📝

### DIFF
--- a/docs/themes/theme_templates.md
+++ b/docs/themes/theme_templates.md
@@ -2,7 +2,7 @@
 
 As a theme developer, you can make customizations more accessible to your users via page and block templates. These templates allow you to override Omeka S's default markup for pages and blocks, and have those appear within the Omeka S admin's page builder interface.
 
-There are two parts required for Omeka S to recognize a theme's template: the theme file must exist within `view/common/page_template` or `view/common/block_template` in the theme directory, and the template must be registered in the `theme.ini`.
+There are two parts required for Omeka S to recognize a theme's template: the theme file must exist within `view/common/page-template` or `view/common/block-template` in the theme directory, and the template must be registered in the `theme.ini`.
 
 In the `theme.ini`, the format for registering a block template looks like this:
 
@@ -24,10 +24,10 @@ This is a list of the available core blocks and how they should be referenced in
 * Page title - `pageTitle`
 * Table of contents - `tableOfContents`
 
-The `[template-filename]` is the name of the template in `view/common/block_template` without the `.phtml` file extension. The `[Template display name]` is what appears in the page builder interface where the user selects the block template.
+The `[template-filename]` is the name of the template in `view/common/block-template` without the `.phtml` file extension. The `[Template display name]` is what appears in the page builder interface where the user selects the block template.
 
 !!! Example
-    For a block template that presents the media embed block as a gallery, you could create a file at `view/common/block_template/gallery.phtml`. In the `theme.ini`, you would register it by including `block_templates.media.gallery = "Gallery"`.
+    For a block template that presents the media embed block as a gallery, you could create a file at `view/common/block-template/gallery.phtml`. In the `theme.ini`, you would register it by including `block_templates.media.gallery = "Gallery"`.
 
 In the `theme.ini`, the format for registering a page template looks like this:
 
@@ -35,7 +35,7 @@ In the `theme.ini`, the format for registering a page template looks like this:
 page_templates.[template-filename] = "[Template display name]"
 ```
 
-Similar to block templates, `[template-filename]` is the name of the template in `view/common/page_template` without the `.phtml` file extension, while `[Template display name]` is what appears in the page builder interface where the user selects the page template.
+Similar to block templates, `[template-filename]` is the name of the template in `view/common/page-template` without the `.phtml` file extension, while `[Template display name]` is what appears in the page builder interface where the user selects the page template.
 
 !!! Example
-    For a page template that provides custom markup for a javascript timeline, you could create a file at `view/common/page_templates/js-timeline.phtml`. In the `theme.ini`, you would register it by including `page_templates.js-timeline = "Javascript timeline"`.
+    For a page template that provides custom markup for a javascript timeline, you could create a file at `view/common/page-templates/js-timeline.phtml`. In the `theme.ini`, you would register it by including `page_templates.js-timeline = "Javascript timeline"`.


### PR DESCRIPTION
The help dox currently say (in https://omeka.org/s/docs/developer/themes/theme_templates/) that theme template files live in "`view/common/page_template` or `view/common/block_template`" but looking at the directory structure of the Default theme, the folder names are `page-template` and `block-template` instead.