### PR TITLE
Fixed typo in Mapping module documentation

### DIFF
--- a/docs/module_docs/Mapping.md
+++ b/docs/module_docs/Mapping.md
@@ -10,5 +10,5 @@ this repository for release. Run `$ npm install` in the the module's /asset dire
 
 - `/api/mappings`
 - `/api/mappings/:id`
-- `/api/mappmapping_featuresings`
+- `/api/mapping_features`
 - `/api/mapping_features/:id`


### PR DESCRIPTION
Looks like some text got auto copypasta'd incorrectly or maybe got combined at the Interdimensional Hole of Pancakes