### PR TITLE
Pass PhpRenderer instead of ViewModel on "Introduction to modules" page

### DIFF
--- a/docs/modules/index.md
+++ b/docs/modules/index.md
@@ -144,7 +144,7 @@ in your module class, like below:
 namespace MyModule;
 
 use Omeka\Module\AbstractModule;
-use Laminas\View\Model\ViewModel;
+use Laminas\View\Renderer\PhpRenderer;
 use Laminas\Mvc\Controller\AbstractController;
 
 class Module extends AbstractModule
@@ -157,7 +157,7 @@ class Module extends AbstractModule
      * @param ViewModel $view
      * @return string
      */
-    public function getConfigForm(ViewModel $view)
+    public function getConfigForm(PhpRenderer $renderer)
     {
         return '<input name="foo">';
     }


### PR DESCRIPTION
I came across a mistake in the module documentation. 
The `AbstractModule` class requires that the `getConfigForm()` method uses a PhpRenderer instead of ViewModel. 

This has been changed in the AbstractModule class a [long time ago](https://github.com/omeka/omeka-s/commit/21199a1714039af9da885a849987f35707c27a97).

I have updated the developer documentation for this. 


Best regards,
Maarten Coonen